### PR TITLE
Change viem usage for EAS to get typed data

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -49,13 +49,11 @@ export function decodeTransactionInput(
   return transactionDescriptor;
 }
 
-export function decodeTransactionInputViem(input: Hex, abi: Abi) {
-  const result = decodeFunctionData({
+export function decodeTransactionInputViem<TAbi extends Abi>(input: Hex, abi: TAbi) {
+  return decodeFunctionData({
     abi,
     data: input,
   });
-
-  return result;
 }
 
 export function decodeLog(abi: Abi, data: Hex, topics: EventLogTopics) {

--- a/src/protocol/eas/abis/EAS.ts
+++ b/src/protocol/eas/abis/EAS.ts
@@ -1,4 +1,4 @@
-[
+const abi = [
   {
     "inputs": [
       {
@@ -1017,4 +1017,6 @@
     "stateMutability": "nonpayable",
     "type": "function"
   }
-]
+] as const;
+
+export default abi;

--- a/src/protocol/eas/constants.ts
+++ b/src/protocol/eas/constants.ts
@@ -1,4 +1,4 @@
-import EAS from './abis/EAS.json';
+import EAS from './abis/EAS';
 import SchemaRegistry from './abis/SchemaRegistry.json';
 
 export const EAS_ADDRESSES = [

--- a/src/protocol/eas/eas.ts
+++ b/src/protocol/eas/eas.ts
@@ -1,4 +1,4 @@
-import { Abi, Hex } from 'viem';
+import { Hex } from 'viem';
 import { Transaction } from '../../types';
 import { decodeTransactionInputViem } from '../../helpers/utils';
 import { ABIs, EAS_LINKS } from './constants';
@@ -31,7 +31,7 @@ export const detect = (transaction: Transaction): boolean => {
     try {
       decoded = decodeTransactionInputViem(
         transaction.input as Hex,
-        ABIs.EAS as Abi,
+        ABIs.EAS,
       );
     } catch (err) {
       return false;
@@ -66,7 +66,7 @@ const pluralize = (word: string, n: number): string => {
 export const generate = (transaction: Transaction): Transaction => {
   const decoded = decodeTransactionInputViem(
     transaction.input as Hex,
-    ABIs.EAS as Abi,
+    ABIs.EAS,
   );
 
   switch (decoded.functionName) {

--- a/src/protocol/eas/eas.ts
+++ b/src/protocol/eas/eas.ts
@@ -48,7 +48,7 @@ export const detect = (transaction: Transaction): boolean => {
       'timestamp',
       'multiTimestamp',
       'revokeOffchain',
-      'multiRevokeOffChain',
+      'multiRevokeOffchain',
     ];
 
     return handledFunctions.includes(decoded.functionName);

--- a/src/protocol/eas/eas.ts
+++ b/src/protocol/eas/eas.ts
@@ -1,4 +1,5 @@
 import { Hex } from 'viem';
+import { ExtractAbiFunctionNames } from 'abitype';
 import { Transaction } from '../../types';
 import { decodeTransactionInputViem } from '../../helpers/utils';
 import { ABIs, EAS_LINKS } from './constants';
@@ -27,18 +28,15 @@ export const detect = (transaction: Transaction): boolean => {
     }
 
     // decode input
-    let decoded;
+    let decoded: ReturnType<typeof decodeTransactionInputViem<typeof ABIs.EAS>>;
     try {
-      decoded = decodeTransactionInputViem(
-        transaction.input as Hex,
-        ABIs.EAS,
-      );
+      decoded = decodeTransactionInputViem(transaction.input as Hex, ABIs.EAS);
     } catch (err) {
       return false;
     }
 
     if (!decoded || !decoded.functionName) return false;
-    return [
+    const handledFunctions: ExtractAbiFunctionNames<typeof ABIs.EAS>[] = [
       'attest',
       'attestByDelegation',
       'multiAttest',
@@ -51,7 +49,9 @@ export const detect = (transaction: Transaction): boolean => {
       'multiTimestamp',
       'revokeOffchain',
       'multiRevokeOffChain',
-    ].includes(decoded.functionName);
+    ];
+
+    return handledFunctions.includes(decoded.functionName);
   } catch (err) {
     console.error('Error in detect function:', err);
     return false;

--- a/src/protocol/eas/eas.ts
+++ b/src/protocol/eas/eas.ts
@@ -487,7 +487,7 @@ export const generate = (transaction: Transaction): Transaction => {
       return transaction;
     }
 
-    case 'multiRevokeOffChain': {
+    case 'multiRevokeOffchain': {
       const data = decoded.args[0];
       transaction.context = {
         variables: {

--- a/src/protocol/eas/eas.ts
+++ b/src/protocol/eas/eas.ts
@@ -71,14 +71,9 @@ export const generate = (transaction: Transaction): Transaction => {
 
   switch (decoded.functionName) {
     case 'attest': {
-      const arg = decoded.args[0] as {
-        schema: string;
-        data: {
-          recipient: string;
-        };
-      };
-      const schema = arg?.schema;
-      const recipient = arg?.data?.recipient;
+      const arg = decoded.args[0];
+      const schema = arg.schema;
+      const recipient = arg.data.recipient;
 
       transaction.context = {
         variables: {
@@ -116,16 +111,10 @@ export const generate = (transaction: Transaction): Transaction => {
     }
 
     case 'attestByDelegation': {
-      const arg = decoded.args[0] as {
-        schema: string;
-        attester: string;
-        data: {
-          recipient: string;
-        };
-      };
-      const schema = arg?.schema;
-      const attester = arg?.attester;
-      const recipient = arg?.data?.recipient;
+      const arg = decoded.args[0];
+      const schema = arg.schema;
+      const attester = arg.attester;
+      const recipient = arg.data.recipient;
 
       transaction.context = {
         variables: {
@@ -167,18 +156,9 @@ export const generate = (transaction: Transaction): Transaction => {
     }
 
     case 'multiAttest': {
-      const arg = decoded.args[0] as [
-        {
-          schema: string;
-          data: [
-            {
-              recipient: string;
-            },
-          ];
-        },
-      ];
-      const schemas = arg?.length;
-      const count = arg?.map((v) => v.data).flat().length;
+      const arg = decoded.args[0];
+      const schemas = arg.length;
+      const count = arg.map((v) => v.data).flat().length;
 
       transaction.context = {
         variables: {
@@ -216,20 +196,10 @@ export const generate = (transaction: Transaction): Transaction => {
     }
 
     case 'multiAttestByDelegation': {
-      const arg = decoded.args[0] as [
-        {
-          schema: string;
-          attester: string;
-          data: [
-            {
-              recipient: string;
-            },
-          ];
-        },
-      ];
-      const schemas = arg?.length;
-      const attesters = Array.from(new Set(arg?.map((v) => v.attester))).length;
-      const count = arg?.map((v) => v.data).flat().length;
+      const arg = decoded.args[0];
+      const schemas = arg.length;
+      const attesters = Array.from(new Set(arg.map((v) => v.attester))).length;
+      const count = arg.map((v) => v.data).flat().length;
 
       transaction.context = {
         variables: {
@@ -278,10 +248,8 @@ export const generate = (transaction: Transaction): Transaction => {
     }
 
     case 'revoke': {
-      const arg = decoded.args[0] as {
-        schema: string;
-      };
-      const schema = arg?.schema;
+      const arg = decoded.args[0];
+      const schema = arg.schema;
 
       transaction.context = {
         variables: {
@@ -314,10 +282,7 @@ export const generate = (transaction: Transaction): Transaction => {
     }
 
     case 'revokeByDelegation': {
-      const arg = decoded.args[0] as {
-        schema: string;
-        revoker: string;
-      };
+      const arg = decoded.args[0];
       const { schema, revoker } = arg;
 
       transaction.context = {
@@ -355,18 +320,9 @@ export const generate = (transaction: Transaction): Transaction => {
     }
 
     case 'multiRevoke': {
-      const arg = decoded.args[0] as [
-        {
-          schema: string;
-          data: [
-            {
-              recipient: string;
-            },
-          ];
-        },
-      ];
-      const schemas = arg?.length;
-      const count = arg?.map((v) => v.data).flat().length;
+      const arg = decoded.args[0];
+      const schemas = arg.length;
+      const count = arg.map((v) => v.data).flat().length;
 
       transaction.context = {
         variables: {
@@ -406,18 +362,10 @@ export const generate = (transaction: Transaction): Transaction => {
     }
 
     case 'multiRevokeByDelegation': {
-      const arg = decoded.args[0] as [
-        {
-          schema: string;
-          revoker: string;
-          data: {
-            recipient: string;
-          };
-        },
-      ];
-      const schemas = arg?.length;
-      const revokers = Array.from(new Set(arg?.map((v) => v.revoker))).length;
-      const count = arg?.map((v) => v.data).flat().length;
+      const arg = decoded.args[0];
+      const schemas = arg.length;
+      const revokers = Array.from(new Set(arg.map((v) => v.revoker))).length;
+      const count = arg.map((v) => v.data).flat().length;
 
       transaction.context = {
         variables: {
@@ -488,14 +436,7 @@ export const generate = (transaction: Transaction): Transaction => {
     }
 
     case 'multiTimestamp': {
-      const arg = decoded.args[0] as {
-        data: [
-          {
-            recipient: string;
-          },
-        ];
-      };
-      const data = arg?.data;
+      const data = decoded.args[0];
       transaction.context = {
         variables: {
           from: {
@@ -547,14 +488,7 @@ export const generate = (transaction: Transaction): Transaction => {
     }
 
     case 'multiRevokeOffChain': {
-      const arg = decoded.args[0] as {
-        data: [
-          {
-            recipient: string;
-          },
-        ];
-      };
-      const data = arg?.data;
+      const data = decoded.args[0];
       transaction.context = {
         variables: {
           from: {


### PR DESCRIPTION
Viem helped catch a bug here! I made a typo in one of the function names, `multiRevokeOffchain`. I had written `multiRevokeOffChain` with a capital C, and tsc knew that `switch (decoded.functionName)` could never match on that name with a cpaital C because the data is typed :)