### PR TITLE
Fix cryptopunks contextualizer to get typed data back from decodeTransactionInput

### DIFF
--- a/src/protocol/cryptopunks/abis/Cryptopunks.ts
+++ b/src/protocol/cryptopunks/abis/Cryptopunks.ts
@@ -3,21 +3,46 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'name',
-    outputs: [{ name: '', type: 'string' }],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: true,
-    inputs: [{ name: '', type: 'uint256' }],
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     name: 'punksOfferedForSale',
     outputs: [
-      { name: 'isForSale', type: 'bool' },
-      { name: 'punkIndex', type: 'uint256' },
-      { name: 'seller', type: 'address' },
-      { name: 'minValue', type: 'uint256' },
-      { name: 'onlySellTo', type: 'address' },
+      {
+        name: 'isForSale',
+        type: 'bool',
+      },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        name: 'seller',
+        type: 'address',
+      },
+      {
+        name: 'minValue',
+        type: 'uint256',
+      },
+      {
+        name: 'onlySellTo',
+        type: 'address',
+      },
     ],
     payable: false,
     type: 'function',
@@ -25,7 +50,12 @@ const abi = [
   },
   {
     constant: false,
-    inputs: [{ name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'enterBidForPunk',
     outputs: [],
     payable: true,
@@ -36,7 +66,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'totalSupply',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -44,8 +79,14 @@ const abi = [
   {
     constant: false,
     inputs: [
-      { name: 'punkIndex', type: 'uint256' },
-      { name: 'minPrice', type: 'uint256' },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        name: 'minPrice',
+        type: 'uint256',
+      },
     ],
     name: 'acceptBidForPunk',
     outputs: [],
@@ -57,7 +98,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'decimals',
-    outputs: [{ name: '', type: 'uint8' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint8',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -65,8 +111,14 @@ const abi = [
   {
     constant: false,
     inputs: [
-      { name: 'addresses', type: 'address[]' },
-      { name: 'indices', type: 'uint256[]' },
+      {
+        name: 'addresses',
+        type: 'address[]',
+      },
+      {
+        name: 'indices',
+        type: 'uint256[]',
+      },
     ],
     name: 'setInitialOwners',
     outputs: [],
@@ -87,7 +139,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'imageHash',
-    outputs: [{ name: '', type: 'string' }],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -96,16 +153,31 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'nextPunkIndexToAssign',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: true,
-    inputs: [{ name: '', type: 'uint256' }],
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     name: 'punkIndexToAddress',
-    outputs: [{ name: '', type: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -114,20 +186,11 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'standard',
-    outputs: [{ name: '', type: 'string' }],
-    payable: false,
-    type: 'function',
-    stateMutability: 'view',
-  },
-  {
-    constant: true,
-    inputs: [{ name: '', type: 'uint256' }],
-    name: 'punkBids',
     outputs: [
-      { name: 'hasBid', type: 'bool' },
-      { name: 'punkIndex', type: 'uint256' },
-      { name: 'bidder', type: 'address' },
-      { name: 'value', type: 'uint256' },
+      {
+        name: '',
+        type: 'string',
+      },
     ],
     payable: false,
     type: 'function',
@@ -135,9 +198,50 @@ const abi = [
   },
   {
     constant: true,
-    inputs: [{ name: '', type: 'address' }],
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'punkBids',
+    outputs: [
+      {
+        name: 'hasBid',
+        type: 'bool',
+      },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        name: 'bidder',
+        type: 'address',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    type: 'function',
+    stateMutability: 'view',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
     name: 'balanceOf',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -155,14 +259,24 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'allPunksAssigned',
-    outputs: [{ name: '', type: 'bool' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: false,
-    inputs: [{ name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'buyPunk',
     outputs: [],
     payable: true,
@@ -172,8 +286,14 @@ const abi = [
   {
     constant: false,
     inputs: [
-      { name: 'to', type: 'address' },
-      { name: 'punkIndex', type: 'uint256' },
+      {
+        name: 'to',
+        type: 'address',
+      },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
     ],
     name: 'transferPunk',
     outputs: [],
@@ -185,14 +305,24 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'symbol',
-    outputs: [{ name: '', type: 'string' }],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: false,
-    inputs: [{ name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'withdrawBidForPunk',
     outputs: [],
     payable: false,
@@ -202,8 +332,14 @@ const abi = [
   {
     constant: false,
     inputs: [
-      { name: 'to', type: 'address' },
-      { name: 'punkIndex', type: 'uint256' },
+      {
+        name: 'to',
+        type: 'address',
+      },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
     ],
     name: 'setInitialOwner',
     outputs: [],
@@ -214,9 +350,18 @@ const abi = [
   {
     constant: false,
     inputs: [
-      { name: 'punkIndex', type: 'uint256' },
-      { name: 'minSalePriceInWei', type: 'uint256' },
-      { name: 'toAddress', type: 'address' },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        name: 'minSalePriceInWei',
+        type: 'uint256',
+      },
+      {
+        name: 'toAddress',
+        type: 'address',
+      },
     ],
     name: 'offerPunkForSaleToAddress',
     outputs: [],
@@ -228,7 +373,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'punksRemainingToAssign',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -236,8 +386,14 @@ const abi = [
   {
     constant: false,
     inputs: [
-      { name: 'punkIndex', type: 'uint256' },
-      { name: 'minSalePriceInWei', type: 'uint256' },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        name: 'minSalePriceInWei',
+        type: 'uint256',
+      },
     ],
     name: 'offerPunkForSale',
     outputs: [],
@@ -247,7 +403,12 @@ const abi = [
   },
   {
     constant: false,
-    inputs: [{ name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'getPunk',
     outputs: [],
     payable: false,
@@ -256,16 +417,31 @@ const abi = [
   },
   {
     constant: true,
-    inputs: [{ name: '', type: 'address' }],
+    inputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
     name: 'pendingWithdrawals',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: false,
-    inputs: [{ name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'punkNoLongerForSale',
     outputs: [],
     payable: false,
@@ -281,8 +457,16 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'to', type: 'address' },
-      { indexed: false, name: 'punkIndex', type: 'uint256' },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
     ],
     name: 'Assign',
     type: 'event',
@@ -290,9 +474,21 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'from', type: 'address' },
-      { indexed: true, name: 'to', type: 'address' },
-      { indexed: false, name: 'value', type: 'uint256' },
+      {
+        indexed: true,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
     ],
     name: 'Transfer',
     type: 'event',
@@ -300,9 +496,21 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'from', type: 'address' },
-      { indexed: true, name: 'to', type: 'address' },
-      { indexed: false, name: 'punkIndex', type: 'uint256' },
+      {
+        indexed: true,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
     ],
     name: 'PunkTransfer',
     type: 'event',
@@ -310,9 +518,21 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'punkIndex', type: 'uint256' },
-      { indexed: false, name: 'minValue', type: 'uint256' },
-      { indexed: true, name: 'toAddress', type: 'address' },
+      {
+        indexed: true,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'minValue',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        name: 'toAddress',
+        type: 'address',
+      },
     ],
     name: 'PunkOffered',
     type: 'event',
@@ -320,9 +540,21 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'punkIndex', type: 'uint256' },
-      { indexed: false, name: 'value', type: 'uint256' },
-      { indexed: true, name: 'fromAddress', type: 'address' },
+      {
+        indexed: true,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        name: 'fromAddress',
+        type: 'address',
+      },
     ],
     name: 'PunkBidEntered',
     type: 'event',
@@ -330,9 +562,21 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'punkIndex', type: 'uint256' },
-      { indexed: false, name: 'value', type: 'uint256' },
-      { indexed: true, name: 'fromAddress', type: 'address' },
+      {
+        indexed: true,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        name: 'fromAddress',
+        type: 'address',
+      },
     ],
     name: 'PunkBidWithdrawn',
     type: 'event',
@@ -340,17 +584,39 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'punkIndex', type: 'uint256' },
-      { indexed: false, name: 'value', type: 'uint256' },
-      { indexed: true, name: 'fromAddress', type: 'address' },
-      { indexed: true, name: 'toAddress', type: 'address' },
+      {
+        indexed: true,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        name: 'fromAddress',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'toAddress',
+        type: 'address',
+      },
     ],
     name: 'PunkBought',
     type: 'event',
   },
   {
     anonymous: false,
-    inputs: [{ indexed: true, name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        indexed: true,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'PunkNoLongerForSale',
     type: 'event',
   },

--- a/src/protocol/cryptopunks/abis/Cryptopunks.ts
+++ b/src/protocol/cryptopunks/abis/Cryptopunks.ts
@@ -6,6 +6,7 @@ const abi = [
     outputs: [{ name: '', type: 'string' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -20,6 +21,7 @@ const abi = [
     ],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -28,6 +30,7 @@ const abi = [
     outputs: [],
     payable: true,
     type: 'function',
+    stateMutability: 'payable',
   },
   {
     constant: true,
@@ -36,6 +39,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -47,6 +51,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -55,6 +60,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint8' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -66,6 +72,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: false,
@@ -74,6 +81,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -82,6 +90,7 @@ const abi = [
     outputs: [{ name: '', type: 'string' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -90,6 +99,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -98,6 +108,7 @@ const abi = [
     outputs: [{ name: '', type: 'address' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -106,6 +117,7 @@ const abi = [
     outputs: [{ name: '', type: 'string' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -119,6 +131,7 @@ const abi = [
     ],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -127,6 +140,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -135,6 +149,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -143,6 +158,7 @@ const abi = [
     outputs: [{ name: '', type: 'bool' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -151,6 +167,7 @@ const abi = [
     outputs: [],
     payable: true,
     type: 'function',
+    stateMutability: 'payable',
   },
   {
     constant: false,
@@ -162,6 +179,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -170,6 +188,7 @@ const abi = [
     outputs: [{ name: '', type: 'string' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -178,6 +197,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: false,
@@ -189,6 +209,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: false,
@@ -201,6 +222,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -209,6 +231,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -220,6 +243,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: false,
@@ -228,6 +252,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -236,6 +261,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -244,8 +270,14 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
-  { inputs: [], payable: true, type: 'constructor' },
+  {
+    inputs: [],
+    payable: true,
+    type: 'constructor',
+    stateMutability: 'payable',
+  },
   {
     anonymous: false,
     inputs: [

--- a/src/protocol/cryptopunks/abis/CryptopunksOld.ts
+++ b/src/protocol/cryptopunks/abis/CryptopunksOld.ts
@@ -6,6 +6,7 @@ const abi = [
     outputs: [{ name: '', type: 'string' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -14,6 +15,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -28,6 +30,7 @@ const abi = [
     ],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -36,6 +39,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -44,6 +48,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint8' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -52,6 +57,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -60,6 +66,7 @@ const abi = [
     outputs: [{ name: '', type: 'string' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -68,6 +75,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -76,6 +84,7 @@ const abi = [
     outputs: [{ name: '', type: 'address' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -84,6 +93,7 @@ const abi = [
     outputs: [{ name: '', type: 'string' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -92,6 +102,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -100,6 +111,7 @@ const abi = [
     outputs: [],
     payable: true,
     type: 'function',
+    stateMutability: 'payable',
   },
   {
     constant: false,
@@ -111,6 +123,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -119,6 +132,7 @@ const abi = [
     outputs: [{ name: '', type: 'string' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -127,6 +141,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: true,
@@ -135,6 +150,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -147,6 +163,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -155,6 +172,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -166,6 +184,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: false,
@@ -174,6 +193,7 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
   {
     constant: true,
@@ -182,6 +202,7 @@ const abi = [
     outputs: [{ name: '', type: 'uint256' }],
     payable: false,
     type: 'function',
+    stateMutability: 'view',
   },
   {
     constant: false,
@@ -190,8 +211,14 @@ const abi = [
     outputs: [],
     payable: false,
     type: 'function',
+    stateMutability: 'nonpayable',
   },
-  { inputs: [], payable: true, type: 'constructor' },
+  {
+    inputs: [],
+    payable: true,
+    type: 'constructor',
+    stateMutability: 'payable',
+  },
   {
     anonymous: false,
     inputs: [

--- a/src/protocol/cryptopunks/abis/CryptopunksOld.ts
+++ b/src/protocol/cryptopunks/abis/CryptopunksOld.ts
@@ -3,14 +3,24 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'name',
-    outputs: [{ name: '', type: 'string' }],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: false,
-    inputs: [{ name: 'maxForThisRun', type: 'uint256' }],
+    inputs: [
+      {
+        name: 'maxForThisRun',
+        type: 'uint256',
+      },
+    ],
     name: 'reservePunksForOwner',
     outputs: [],
     payable: false,
@@ -19,14 +29,34 @@ const abi = [
   },
   {
     constant: true,
-    inputs: [{ name: '', type: 'uint256' }],
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     name: 'punksOfferedForSale',
     outputs: [
-      { name: 'isForSale', type: 'bool' },
-      { name: 'punkIndex', type: 'uint256' },
-      { name: 'seller', type: 'address' },
-      { name: 'minValue', type: 'uint256' },
-      { name: 'onlySellTo', type: 'address' },
+      {
+        name: 'isForSale',
+        type: 'bool',
+      },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        name: 'seller',
+        type: 'address',
+      },
+      {
+        name: 'minValue',
+        type: 'uint256',
+      },
+      {
+        name: 'onlySellTo',
+        type: 'address',
+      },
     ],
     payable: false,
     type: 'function',
@@ -36,7 +66,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'totalSupply',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -45,7 +80,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'decimals',
-    outputs: [{ name: '', type: 'uint8' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint8',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -63,7 +103,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'imageHash',
-    outputs: [{ name: '', type: 'string' }],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -72,16 +117,31 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'nextPunkIndexToAssign',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: true,
-    inputs: [{ name: '', type: 'uint256' }],
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     name: 'punkIndexToAddress',
-    outputs: [{ name: '', type: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -90,23 +150,43 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'standard',
-    outputs: [{ name: '', type: 'string' }],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: true,
-    inputs: [{ name: '', type: 'address' }],
+    inputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
     name: 'balanceOf',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: false,
-    inputs: [{ name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'buyPunk',
     outputs: [],
     payable: true,
@@ -116,8 +196,14 @@ const abi = [
   {
     constant: false,
     inputs: [
-      { name: 'to', type: 'address' },
-      { name: 'punkIndex', type: 'uint256' },
+      {
+        name: 'to',
+        type: 'address',
+      },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
     ],
     name: 'transferPunk',
     outputs: [],
@@ -129,7 +215,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'symbol',
-    outputs: [{ name: '', type: 'string' }],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -138,7 +229,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'numberOfPunksToReserve',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -147,7 +243,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'numberOfPunksReserved',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -155,9 +256,18 @@ const abi = [
   {
     constant: false,
     inputs: [
-      { name: 'punkIndex', type: 'uint256' },
-      { name: 'minSalePriceInWei', type: 'uint256' },
-      { name: 'toAddress', type: 'address' },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        name: 'minSalePriceInWei',
+        type: 'uint256',
+      },
+      {
+        name: 'toAddress',
+        type: 'address',
+      },
     ],
     name: 'offerPunkForSaleToAddress',
     outputs: [],
@@ -169,7 +279,12 @@ const abi = [
     constant: true,
     inputs: [],
     name: 'punksRemainingToAssign',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
@@ -177,8 +292,14 @@ const abi = [
   {
     constant: false,
     inputs: [
-      { name: 'punkIndex', type: 'uint256' },
-      { name: 'minSalePriceInWei', type: 'uint256' },
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        name: 'minSalePriceInWei',
+        type: 'uint256',
+      },
     ],
     name: 'offerPunkForSale',
     outputs: [],
@@ -188,7 +309,12 @@ const abi = [
   },
   {
     constant: false,
-    inputs: [{ name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'getPunk',
     outputs: [],
     payable: false,
@@ -197,16 +323,31 @@ const abi = [
   },
   {
     constant: true,
-    inputs: [{ name: '', type: 'address' }],
+    inputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
     name: 'pendingWithdrawals',
-    outputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
     payable: false,
     type: 'function',
     stateMutability: 'view',
   },
   {
     constant: false,
-    inputs: [{ name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'punkNoLongerForSale',
     outputs: [],
     payable: false,
@@ -222,8 +363,16 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'to', type: 'address' },
-      { indexed: false, name: 'punkIndex', type: 'uint256' },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
     ],
     name: 'Assign',
     type: 'event',
@@ -231,9 +380,21 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'from', type: 'address' },
-      { indexed: true, name: 'to', type: 'address' },
-      { indexed: false, name: 'value', type: 'uint256' },
+      {
+        indexed: true,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
     ],
     name: 'Transfer',
     type: 'event',
@@ -241,9 +402,21 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'from', type: 'address' },
-      { indexed: true, name: 'to', type: 'address' },
-      { indexed: false, name: 'punkIndex', type: 'uint256' },
+      {
+        indexed: true,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
     ],
     name: 'PunkTransfer',
     type: 'event',
@@ -251,9 +424,21 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'punkIndex', type: 'uint256' },
-      { indexed: false, name: 'minValue', type: 'uint256' },
-      { indexed: true, name: 'toAddress', type: 'address' },
+      {
+        indexed: true,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'minValue',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        name: 'toAddress',
+        type: 'address',
+      },
     ],
     name: 'PunkOffered',
     type: 'event',
@@ -261,17 +446,39 @@ const abi = [
   {
     anonymous: false,
     inputs: [
-      { indexed: true, name: 'punkIndex', type: 'uint256' },
-      { indexed: false, name: 'value', type: 'uint256' },
-      { indexed: true, name: 'fromAddress', type: 'address' },
-      { indexed: true, name: 'toAddress', type: 'address' },
+      {
+        indexed: true,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        name: 'fromAddress',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'toAddress',
+        type: 'address',
+      },
     ],
     name: 'PunkBought',
     type: 'event',
   },
   {
     anonymous: false,
-    inputs: [{ indexed: true, name: 'punkIndex', type: 'uint256' }],
+    inputs: [
+      {
+        indexed: true,
+        name: 'punkIndex',
+        type: 'uint256',
+      },
+    ],
     name: 'PunkNoLongerForSale',
     type: 'event',
   },

--- a/src/protocol/cryptopunks/constants.ts
+++ b/src/protocol/cryptopunks/constants.ts
@@ -7,6 +7,6 @@ export const CryptopunksContracts = {
 } as const;
 
 export const CRYPTOPUNK_ABIS = {
-  '0x6ba6f2207e343923ba692e5cae646fb0f566db8d': cryptoPunksOldAbi,
-  '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb': cryptoPunksAbi,
+  [CryptopunksContracts.Old]: cryptoPunksOldAbi,
+  [CryptopunksContracts.New]: cryptoPunksAbi,
 };

--- a/src/protocol/cryptopunks/constants.ts
+++ b/src/protocol/cryptopunks/constants.ts
@@ -4,7 +4,7 @@ import cryptoPunksAbi from './abis/Cryptopunks';
 export const CryptopunksContracts = {
   Old: '0x6ba6f2207e343923ba692e5cae646fb0f566db8d',
   New: '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
-};
+} as const;
 
 export const CRYPTOPUNK_ABIS = {
   '0x6ba6f2207e343923ba692e5cae646fb0f566db8d': cryptoPunksOldAbi,

--- a/src/protocol/cryptopunks/cryptopunks.ts
+++ b/src/protocol/cryptopunks/cryptopunks.ts
@@ -51,9 +51,16 @@ export const detect = (transaction: Transaction): boolean => {
 
 // Contextualize for mined txs
 export const generate = (transaction: Transaction): Transaction => {
+  if (
+    transaction.to !== CryptopunksContracts.Old &&
+    transaction.to !== CryptopunksContracts.New
+  ) {
+    return transaction;
+  }
+
   const decoded = decodeTransactionInput(
     transaction.input as Hex,
-    CRYPTOPUNK_ABIS[transaction.to], // TODO: Get this ABI from a separate typed abi ts file
+    CRYPTOPUNK_ABIS[transaction.to],
   );
 
   switch (decoded.functionName) {

--- a/src/protocol/cryptopunks/cryptopunks.ts
+++ b/src/protocol/cryptopunks/cryptopunks.ts
@@ -68,7 +68,7 @@ export const generate = (transaction: Transaction): Transaction => {
       const punk: ContextSummaryVariableType = {
         type: 'erc721',
         token: CryptopunksContracts.New,
-        tokenId: BigInt(decoded.args[0] as bigint).toString(),
+        tokenId: decoded.args[0].toString(),
       };
       const minter: ContextSummaryVariableType = {
         type: 'address',
@@ -121,11 +121,11 @@ export const generate = (transaction: Transaction): Transaction => {
       const punk: ContextSummaryVariableType = {
         type: 'erc721',
         token: CryptopunksContracts.New,
-        tokenId: BigInt(decoded.args[0] as bigint).toString(),
+        tokenId: decoded.args[0].toString(),
       };
       const price: ContextSummaryVariableType = {
         type: 'eth',
-        value: (decoded.args[1] as bigint).toString(),
+        value: decoded.args[1].toString(),
         unit: 'wei',
       };
       if (transaction.receipt?.status) {
@@ -178,7 +178,7 @@ export const generate = (transaction: Transaction): Transaction => {
       const punk: ContextSummaryVariableType = {
         type: 'erc721',
         token: CryptopunksContracts.New,
-        tokenId: BigInt(decoded.args[0] as bigint).toString(),
+        tokenId: decoded.args[0].toString(),
       };
       const price: ContextSummaryVariableType = {
         type: 'eth',
@@ -235,7 +235,7 @@ export const generate = (transaction: Transaction): Transaction => {
       const punk: ContextSummaryVariableType = {
         type: 'erc721',
         token: CryptopunksContracts.New,
-        tokenId: BigInt(decoded.args[0] as bigint).toString(),
+        tokenId: decoded.args[0].toString(),
       };
       const price: ContextSummaryVariableType = {
         type: 'eth',
@@ -341,7 +341,7 @@ export const generate = (transaction: Transaction): Transaction => {
       const punk: ContextSummaryVariableType = {
         type: 'erc721',
         token: CryptopunksContracts.New,
-        tokenId: BigInt(decoded.args[0] as bigint).toString(),
+        tokenId: decoded.args[0].toString(),
       };
       const price: ContextSummaryVariableType = {
         type: 'eth',
@@ -409,11 +409,11 @@ export const generate = (transaction: Transaction): Transaction => {
       const punk: ContextSummaryVariableType = {
         type: 'erc721',
         token: CryptopunksContracts.New,
-        tokenId: BigInt(decoded.args[1] as bigint).toString(),
+        tokenId: decoded.args[1].toString(),
       };
       const receiver: ContextSummaryVariableType = {
         type: 'address',
-        value: decoded.args[0] as string,
+        value: decoded.args[0],
       };
       if (transaction.receipt?.status) {
         transaction.context = {
@@ -465,7 +465,7 @@ export const generate = (transaction: Transaction): Transaction => {
       const punk: ContextSummaryVariableType = {
         type: 'erc721',
         token: CryptopunksContracts.New,
-        tokenId: BigInt(decoded.args[0] as bigint).toString(),
+        tokenId: decoded.args[0].toString(),
       };
       if (transaction.receipt?.status) {
         transaction.context = {
@@ -515,16 +515,16 @@ export const generate = (transaction: Transaction): Transaction => {
       const punk: ContextSummaryVariableType = {
         type: 'erc721',
         token: CryptopunksContracts.New,
-        tokenId: BigInt(decoded.args[0] as bigint).toString(),
+        tokenId: decoded.args[0].toString(),
       };
       const price: ContextSummaryVariableType = {
         type: 'eth',
-        value: (decoded.args[1] as bigint).toString(),
+        value: decoded.args[1].toString(),
         unit: 'wei',
       };
       const buyer: ContextSummaryVariableType = {
         type: 'address',
-        value: decoded.args[2] as string,
+        value: decoded.args[2],
       };
       if (transaction.receipt?.status) {
         transaction.context = {


### PR DESCRIPTION
The key changes:
- By using the address values defined in `CryptopunksContracts` as keys in `CRYPTOPUNK_ABIS` ts can get the right type of `CRYPTOPUNK_ABIS[transaction.to]` as long as it knows that `transaction.to` is one of those keys, so after a check like this
  ```ts
  if (
    transaction.to !== CryptopunksContracts.Old &&
    transaction.to !== CryptopunksContracts.New
  ) {
    return false;
  }
  ```
  This is why I added this check to `generate` as well
- The cryptopunk contracts were written pre solidity 0.5 (using 0.4.8) which means that they use a really old abi version that is incompatible with viem (lacks the `stateMutability`-field, https://docs.soliditylang.org/en/v0.8.21/050-breaking-changes.html#command-line-and-json-interfaces). I converted them using
  ```ts
  import abi from 'solc/abi.js';

  const outputABI = abi.update("0.4.8", CRYPTOPUNK_ABIS[CryptopunksContracts.Old]);
  console.log(JSON.stringify(outputABI, null, 2));
  ```

The same pattern can be applied to the other protocol implementations