### PR TITLE
Fix EAS SchemaRegistry#create schema link urls

### DIFF
--- a/src/protocol/eas/schemaRegistry.ts
+++ b/src/protocol/eas/schemaRegistry.ts
@@ -88,7 +88,7 @@ export const generate = (transaction: Transaction): Transaction => {
             value: id,
             truncate: true,
             link: EAS_LINKS[transaction.chainId]
-              ? `${EAS_LINKS[transaction.chainId]}/${id}`
+              ? `${EAS_LINKS[transaction.chainId]}/schema/view/${id}`
               : '',
           },
           schema: {


### PR DESCRIPTION
The schema links for `SchemaRegistry#create` transactions are currently broken, they link to https://base.easscan.org/0xb604265b6975a5cd9c62a0ed3851527055224e0e35555d568d6af9c7bf793cea but the link should be https://base.easscan.org/schema/view/0xb604265b6975a5cd9c62a0ed3851527055224e0e35555d568d6af9c7bf793cea

SchemaRegistry on onceupon: https://www.onceupon.gg/0x4200000000000000000000000000000000000020