### PR TITLE
Update tokenTransfer heuristic contextualizer to use abi decoding instead of relying on decode.fragment

### DIFF
--- a/src/heuristics/tokenTransfer/abis/combined.ts
+++ b/src/heuristics/tokenTransfer/abis/combined.ts
@@ -1,0 +1,107 @@
+const abi = [
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenId',
+        type: 'uint256',
+      },
+    ],
+    name: 'safeTransferFrom',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: '_data',
+        type: 'bytes',
+      },
+    ],
+    name: 'safeTransferFrom',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenId',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFrom',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_to',
+        type: 'address',
+      },
+      {
+        name: '_value',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+export default abi;

--- a/src/heuristics/tokenTransfer/tokenTransfer.ts
+++ b/src/heuristics/tokenTransfer/tokenTransfer.ts
@@ -1,8 +1,11 @@
+import { Hex } from 'viem';
 import {
   AssetType,
   ContextSummaryVariableType,
   Transaction,
 } from '../../types';
+import ERC20ERC721transferABI from './abis/combined';
+import { decodeTransactionInput } from '../../helpers/utils';
 
 export function contextualize(transaction: Transaction): Transaction {
   const isTokenTransfer = detect(transaction);
@@ -17,14 +20,12 @@ export function detect(transaction: Transaction): boolean {
   }
 
   // ERC721 transferFrom && safeTransferFrom
-  if (
-    transaction.decode?.fragment.name === 'transfer' ||
-    transaction.decode?.fragment.name === 'transferFrom' ||
-    transaction.decode?.fragment.name === 'safeTransferFrom'
-  ) {
-    if (transaction.assetTransfers?.length === 1) {
-      return true;
-    }
+  const decoded = decodeTransactionInput(transaction.input as Hex, ERC20ERC721transferABI);
+
+  if (!decoded) return false;
+
+  if (transaction.assetTransfers?.length === 1) {
+    return true;
   }
 
   return false;


### PR DESCRIPTION
to be forward compatible with account abstraction